### PR TITLE
[FE] 💄 25) 비밀번호 재설정 화면

### DIFF
--- a/client/src/app/component/sign/SignForm.module.css
+++ b/client/src/app/component/sign/SignForm.module.css
@@ -18,3 +18,18 @@
     width: 40px;
     height: 40px;
 }
+
+.pw_guide_container {
+    position: relative;
+}
+
+.link_tag {
+    position: absolute;
+    top: 0;
+    right: 0;
+    font-size: 12px;
+    color: #0074CC;
+    cursor: pointer;
+    /* position: absolute 설정으로 클릭이 불가한 부분을 해결하기 위한 z-index */
+    z-index: 1;
+}

--- a/client/src/app/component/sign/login/SignInForm.jsx
+++ b/client/src/app/component/sign/login/SignInForm.jsx
@@ -1,16 +1,23 @@
+import Link from "next/link";
+
 import SignInput from "@component/sign/SignInput";
 import Button from "@component/sign/Button";
 import styles from "../SignForm.module.css";
 
-function SignUpForm() {
+function SignInForm() {
     return (
         <div className={styles.container}>
             <SignInput label="Email" />
-            <SignInput label="Password" />
+            <div className={styles.pw_guide_container}>
+                <p className={styles.link_tag}>
+                    <Link href="/users/account-recovery">Forget password?</Link>
+                </p>
+                <SignInput label="Password" />
+            </div>
 
             <Button label="Log in" type="Primary" isFullBtn={true} />
         </div>
     );
 }
 
-export default SignUpForm;
+export default SignInForm;

--- a/client/src/app/component/users/FindPwForm.jsx
+++ b/client/src/app/component/users/FindPwForm.jsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useState } from "react";
+import styles from "./FindPwForm.module.css";
+import SignInput from "@component/sign/SignInput";
+import Button from "@component/sign/Button";
+
+function FindPwForm() {
+    const [email, setEmail] = useState("");
+    const [isEmailChecked, setIsEmailChecked] = useState(false);
+
+    return (
+        <div className={styles.container}>
+            {isEmailChecked ? (
+                <>
+                    <p className={styles.guide_msg}>Reset your password for {email}</p>
+                    <SignInput label="New password" />
+                    <SignInput label="New password (again)" />
+                    <Button label="Reset your password" type="Primary" isFullBtn={true} />
+                </>
+            ) : (
+                <>
+                    <p className={styles.guide_msg}>
+                        Forgot your account's password? Enter your email address and we'll check if your email is valid.
+                    </p>
+                    <SignInput label="Email" />
+                    <Button label="Check if your email is valid" type="Primary" isFullBtn={true} />
+                </>
+            )}
+        </div>
+    );
+}
+
+export default FindPwForm;

--- a/client/src/app/component/users/FindPwForm.module.css
+++ b/client/src/app/component/users/FindPwForm.module.css
@@ -1,0 +1,15 @@
+.container {
+    width: 100%;
+    padding: 24px;
+    margin: 24px 0 36px 0;
+    border: 1px solid #E2E2E2;
+    border-radius: 8px;
+    background-color: #ffffff;
+    box-shadow: 0 0 10px 2px #dfdfdf;
+}
+
+.guide_msg {
+    margin-bottom: 32px;
+    color: #727177;
+    font-size: 13px;
+}

--- a/client/src/app/users/account-recovery/AccountRecovery.module.css
+++ b/client/src/app/users/account-recovery/AccountRecovery.module.css
@@ -1,0 +1,45 @@
+.container {
+    display: flex;
+    width: 100%;
+    padding: 24px 16px;
+    background-color: #f1f2f3;
+}
+
+.col_center {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    height: calc(100vh - 100px);
+}
+
+.recovery_title {
+    margin-bottom: 24px;
+    font-size: 27px;
+    font-weight: 400;
+}
+
+/* recovery form width 반응형 */
+.recovery_form_container {
+    width: 420px;
+}
+
+@media screen and (max-height: 700px) {
+    .col_center {
+        height: max-content;
+    }
+}
+
+@media screen and (max-width: 500px) {
+    .recovery_form_container {
+        width: 300px;
+    }
+}
+
+@media screen and (max-width: 320px) {
+    .recovery_form_container {
+        width: 100%;
+    }
+}

--- a/client/src/app/users/account-recovery/AccountRecovery.module.css
+++ b/client/src/app/users/account-recovery/AccountRecovery.module.css
@@ -26,7 +26,7 @@
     width: 420px;
 }
 
-@media screen and (max-height: 700px) {
+@media screen and (max-height: 400px) {
     .col_center {
         height: max-content;
     }

--- a/client/src/app/users/account-recovery/page.jsx
+++ b/client/src/app/users/account-recovery/page.jsx
@@ -1,0 +1,21 @@
+import Layout from "@component/layout/Layout";
+import FindPwForm from "@component/users/FindPwForm";
+
+import styles from "./AccountRecovery.module.css";
+
+function AccountRecovery() {
+    return (
+        <Layout>
+            <div className={styles.container}>
+                <div className={styles.col_center}>
+                    <div className={styles.recovery_form_container}>
+                        <h1 className={styles.recovery_title}>Account Recovery</h1>
+                        <FindPwForm />
+                    </div>
+                </div>
+            </div>
+        </Layout>
+    );
+}
+
+export default AccountRecovery;


### PR DESCRIPTION
### 이슈번호
- #25 

### 작업 내용
- [x] 화면 구현

### 결과 화면
- 비밀번호 재설정 화면
  - 1. 이메일 유효한지 확인하는 화면
  - <img src="https://github.com/codestates-seb/seb45_pre_034/assets/126226314/3a32b4e9-bd3e-4f15-8edd-69b35d8e62d9" width="50%" />
  - 2. 이메일 유효할 경우 비밀번호 재설정
  - <img src="https://github.com/codestates-seb/seb45_pre_034/assets/126226314/ae350c20-3b40-4b2e-8b8c-5fc547ed57da" width="50%" />


### 작업 중 이슈 사항 또는 TODO 로 남겨둔 부분
- 나중에 oauth 작업 시작할 때 유저 정보에 oauth 회원가입인지 여부 저장하면 좋을 것 같습니다!