### PR TITLE
[FE] ✨  Question 데이터 fetch 기능 추가

### DIFF
--- a/client/src/app/component/questions/QuestionSummary.jsx
+++ b/client/src/app/component/questions/QuestionSummary.jsx
@@ -1,9 +1,11 @@
-"use client";
-
 import Link from "next/link";
 import styles from "@component/questions/QuestionSummary.module.css";
+import { usePathname } from "next/navigation";
 
-function QuestionSummary() {
+function QuestionSummary({ data }) {
+    console.log(data);
+    const propData = data;
+
     return (
         <div className={styles.container}>
             <div className={styles.summary}>
@@ -22,24 +24,23 @@ function QuestionSummary() {
                     </div>
                 </div>
                 <div>
-                    <Link href="/questions/post">
-                        <h3 className={styles.h3}>
-                            Lorem ipsum dolor sit amet, consectetur adipisicing elit. A, magni. Autem tempora magnam
-                            dicta! Ipsa dolores et architecto voluptas
-                        </h3>
+                    <Link href={`/questions/${propData.id}`}>
+                        <h3 className={styles.h3}>{propData.title}</h3>
                     </Link>
 
                     <div className={styles.meta}>
-                        <ul className={styles.ul_tag}>
-                            <li>sql</li>
-                            <li>sql-server</li>
-                            <li>sql-like</li>
-                        </ul>
+                        {propData ? (
+                            <ul className={styles.ul_tag}>
+                                {propData.tags.map((el, idx) => (
+                                    <li key={idx}>{el}</li>
+                                ))}
+                            </ul>
+                        ) : null}
 
                         <div className={styles.user_card}>
-                            <div>
+                            {/* <div>
                                 <img src="" alt="유저 아바타" />
-                            </div>
+                            </div> */}
                             <div>
                                 <a href="#">유저 닉네임</a>
                             </div>

--- a/client/src/app/component/questions/QuestionsList.jsx
+++ b/client/src/app/component/questions/QuestionsList.jsx
@@ -1,35 +1,69 @@
 "use client";
-import { usePathname } from "next/navigation";
+
 import SortHandler from "@component/common/SortHandler";
 import QuestionSummary from "./QuestionSummary";
+import Button from "@component/common/Button";
+import { useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
 import styles from "@component/questions/QuestionsList.module.css";
+
 function QuestionsList({ title }) {
     const pathname = usePathname();
 
-    const renderSortHandler = () => {
-        if (pathname === "/") {
-            return <SortHandler btnNameArr={["Interesting", "Hot", "Week", "Month"]} />;
+    const [allPostsData, setAllPostsData] = useState(null);
+    useEffect(() => {
+        async function fetchData() {
+            try {
+                const response = await fetch("https://dummyjson.com/posts", { cache: 'no-store' });
+
+                if (!response.ok) {
+                    throw new Error("Network response was not ok");
+                }
+
+                const data = await response.json();
+                setAllPostsData(data);
+            } catch (error) {
+                console.error("Error fetching data:", error);
+            }
         }
 
-        if (pathname === "/questions") {
-            return <SortHandler btnNameArr={["Newest", "Active", "Unanswered"]} />;
+        fetchData();
+    }, []);
+
+    const RenderSortHandler = () => {
+        let buttons = [];
+        if (pathname === "/") {
+            buttons = ["Interesting", "Hot", "Week", "Month"];
         }
+        if (pathname === "/questions") {
+            buttons = ["Newest", "Active", "Unanswered"];
+        }
+        return <SortHandler btnNameArr={buttons} />;
     };
 
     return (
         <>
             <section className={styles.section}>
                 <header className={styles.header}>
-                    <div className={styles.inner_title_btn_wrap}>
+                    <div className={styles.inner_header_wrap}>
                         <h1 className={styles.title}>{title ? title : "Questions"}</h1>
-                        <button className={styles.ask_q}>Ask Question</button>
+                        <Button type="Primary" label="Ask Question"></Button>
                     </div>
 
-                    <div className={styles.sortHandler_container}>{renderSortHandler()}</div>
+                    <div className={styles.sortHandler_container}>
+                        <RenderSortHandler />
+                    </div>
                 </header>
-                <ul>
-                    <QuestionSummary/>
+
+                {allPostsData ? (
+                <ul className={styles.summary_list}>
+                    {allPostsData.posts.map((el) => (
+                        <li key={el.id}><QuestionSummary data={el}/></li>
+                    ))}
                 </ul>
+            ) : null}
+                    
+
             </section>
         </>
     );

--- a/client/src/app/component/questions/QuestionsList.module.css
+++ b/client/src/app/component/questions/QuestionsList.module.css
@@ -10,20 +10,11 @@
 .title{
     font-size: 27px;
     font-weight: 400;
-    width: 100%;
+    flex-grow: 1;
     margin: 0 12px 12px 0;
 }
 
-.ask_q {
-    min-width: 100px;
-    height: 37px;
-    font-size: 13px;
-    color: white;
-    border-radius: 6px;
-    background-color: #0A95FF;
-}
-
-.inner_title_btn_wrap {
+.inner_header_wrap {
     display: flex;
     /* justify-content: space-between; */
     margin-bottom: 12px;
@@ -32,4 +23,8 @@
 .sortHandler_container {
     display: flex;
     justify-content: right;
+}
+
+.summary_list {
+    list-style: none;
 }

--- a/client/src/app/questions/[id]/page.jsx
+++ b/client/src/app/questions/[id]/page.jsx
@@ -1,4 +1,3 @@
-"use client";
 import AnswerList from "@component/answer/AnswerList";
 import Layout from "@component/layout/Layout";
 import QuestionPost from "@component/questions/QuestionPost";


### PR DESCRIPTION
- [x] QustionList에서 fetch한 데이터를 QuestionSummary에 props 전달해 게시글의 목록을 구성함
- [x] 특정 QuestionSummary를 클릭하면 해당 게시글의 아이디인 url로 이동함
- [ ] QuestionSummary를 클릭 했을 때 QuestionPost에서 해당 게시글의 데이터(본문, 작성자 등)을 표시함 
![image](https://github.com/codestates-seb/seb45_pre_034/assets/85207564/ac87ec44-52a5-4ace-bbf2-613fde69e9f8)
